### PR TITLE
Fix incorrect navigation behaviour for media collections

### DIFF
--- a/app/src/main/java/me/cniekirk/jellydroid/navigation/AppNavigation.kt
+++ b/app/src/main/java/me/cniekirk/jellydroid/navigation/AppNavigation.kt
@@ -46,7 +46,6 @@ import me.cniekirk.jellydroid.feature.onboarding.OnboardingNavigation
 import me.cniekirk.jellydroid.feature.onboarding.onboardingModuleEntries
 import me.cniekirk.jellydroid.feature.settings.Settings
 import me.cniekirk.jellydroid.feature.settings.settings
-import timber.log.Timber
 
 @Serializable
 data object RootHome : NavKey
@@ -62,7 +61,7 @@ fun JellydroidRootNavigation(modifier: Modifier = Modifier) {
         entryDecorators = listOf(
             rememberSceneSetupNavEntryDecorator(),
             rememberSavedStateNavEntryDecorator(),
-//            rememberViewModelStoreNavEntryDecorator()
+            // TODO: Add rememberViewModelStoreNavEntryDecorator() when the library is stable
         ),
         predictivePopTransitionSpec = {
             activityDefaultPopEnter() togetherWith activityDefaultPopExit()

--- a/app/src/main/java/me/cniekirk/jellydroid/navigation/AppNavigation.kt
+++ b/app/src/main/java/me/cniekirk/jellydroid/navigation/AppNavigation.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
@@ -45,6 +46,7 @@ import me.cniekirk.jellydroid.feature.onboarding.OnboardingNavigation
 import me.cniekirk.jellydroid.feature.onboarding.onboardingModuleEntries
 import me.cniekirk.jellydroid.feature.settings.Settings
 import me.cniekirk.jellydroid.feature.settings.settings
+import timber.log.Timber
 
 @Serializable
 data object RootHome : NavKey
@@ -62,6 +64,9 @@ fun JellydroidRootNavigation(modifier: Modifier = Modifier) {
             rememberSavedStateNavEntryDecorator(),
 //            rememberViewModelStoreNavEntryDecorator()
         ),
+        predictivePopTransitionSpec = {
+            activityDefaultPopEnter() togetherWith activityDefaultPopExit()
+        },
         transitionSpec = {
             activityDefaultEnter() togetherWith activityDefaultExit()
         },
@@ -155,6 +160,7 @@ fun JellydroidTabsNavHost(
             entryDecorators = listOf(
                 rememberSceneSetupNavEntryDecorator(),
                 rememberSavedStateNavEntryDecorator(),
+                rememberViewModelStoreNavEntryDecorator()
             ),
             entryProvider = entryProvider {
                 home(
@@ -163,6 +169,7 @@ fun JellydroidTabsNavHost(
                             CollectionKind.MOVIES -> CollectionType.MOVIES
                             CollectionKind.SERIES -> CollectionType.SERIES
                         }
+
                         appBackstack.add(MediaCollection(id, name, type))
                     },
                     onResumeItemClicked = {},

--- a/feature/mediaCollection/src/main/java/me/cniekirk/jellydroid/feature/mediacollection/MediaCollectionNavigation.kt
+++ b/feature/mediaCollection/src/main/java/me/cniekirk/jellydroid/feature/mediacollection/MediaCollectionNavigation.kt
@@ -1,11 +1,17 @@
 package me.cniekirk.jellydroid.feature.mediacollection
 
 import androidx.annotation.Keep
+import androidx.compose.animation.togetherWith
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation3.runtime.EntryProviderBuilder
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
+import androidx.navigation3.ui.NavDisplay
 import kotlinx.serialization.Serializable
+import me.cniekirk.jellydroid.core.designsystem.theme.enterAnimation
+import me.cniekirk.jellydroid.core.designsystem.theme.exitAnimation
+import me.cniekirk.jellydroid.core.designsystem.theme.popEnterAnimation
+import me.cniekirk.jellydroid.core.designsystem.theme.popExitAnimation
 
 @Keep
 @Serializable
@@ -24,7 +30,15 @@ data class MediaCollection(
 fun EntryProviderBuilder<*>.mediaCollection(
     onBackClicked: () -> Unit
 ) {
-    entry<MediaCollection> { key ->
+    entry<MediaCollection>(
+        metadata = NavDisplay.transitionSpec {
+            enterAnimation() togetherWith exitAnimation()
+        } + NavDisplay.popTransitionSpec {
+            popEnterAnimation() togetherWith popExitAnimation()
+        } + NavDisplay.predictivePopTransitionSpec {
+            popEnterAnimation() togetherWith popExitAnimation()
+        }
+    ) { key ->
         val viewModel = hiltViewModel<MediaCollectionViewModel, MediaCollectionViewModel.Factory>(
             creationCallback = { factory -> factory.create(key) }
         )

--- a/feature/mediaDetails/src/main/java/me/cniekirk/jellydroid/feature/mediadetails/MediaDetailsNavigation.kt
+++ b/feature/mediaDetails/src/main/java/me/cniekirk/jellydroid/feature/mediadetails/MediaDetailsNavigation.kt
@@ -1,18 +1,32 @@
 package me.cniekirk.jellydroid.feature.mediadetails
 
+import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation3.runtime.EntryProviderBuilder
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
+import androidx.navigation3.ui.NavDisplay
 import kotlinx.serialization.Serializable
+import me.cniekirk.jellydroid.core.designsystem.theme.enterAnimation
+import me.cniekirk.jellydroid.core.designsystem.theme.exitAnimation
+import me.cniekirk.jellydroid.core.designsystem.theme.popEnterAnimation
+import me.cniekirk.jellydroid.core.designsystem.theme.popExitAnimation
 
 fun EntryProviderBuilder<*>.mediaDetails(
     onPlayClicked: (String) -> Unit,
     onBackClicked: () -> Unit
 ) {
-    entry<MediaDetails> { key ->
+    entry<MediaDetails>(
+        metadata = NavDisplay.transitionSpec {
+            enterAnimation() togetherWith exitAnimation()
+        } + NavDisplay.popTransitionSpec {
+            popEnterAnimation() togetherWith popExitAnimation()
+        } + NavDisplay.predictivePopTransitionSpec {
+            popEnterAnimation() togetherWith popExitAnimation()
+        }
+    ) { key ->
         val playClicked by rememberUpdatedState(onPlayClicked)
         val backClicked by rememberUpdatedState(onBackClicked)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,7 +88,7 @@ androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runt
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
 # Optional add-on libraries
 androidx-material3-navigation3 = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation3", version.ref = "nav3Material" }
-androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "nav3Lifecycle" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "nav3Material" }
 
 
 androidx-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "ui" }


### PR DESCRIPTION
Fixes incorrect navigation behaviour for media collections by scoping VM's to nav entries. This requires the snapshot built of the lifecycle Nav3 lirbray 😟 